### PR TITLE
Separate deploy and start npm commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node deploy-commands.js & node index.js"
+    "start": "node index.js",
+    "deploy": "node deploy-commands.js"
   },
   "author": "cluuless",
   "license": "MPL-2.0",


### PR DESCRIPTION
Makes it less risky to accidentally deploy commands to all servers.

Related Issues:
- https://github.com/cluuless/curio-bot/issues/5